### PR TITLE
엔티티 생성 및 변경 추적을 위한 메타데이터 기능

### DIFF
--- a/src/main/java/io/jeidiiy/sirenordersystem/order/domain/Order.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/order/domain/Order.java
@@ -3,6 +3,7 @@ package io.jeidiiy.sirenordersystem.order.domain;
 import io.jeidiiy.sirenordersystem.store.domain.Store;
 import io.jeidiiy.sirenordersystem.user.domain.User;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,6 +34,10 @@ public class Order {
   @Column
   private OrderStatus orderStatus;
 
+  @Column private LocalDateTime createdAt;
+
+  @Column private LocalDateTime updatedAt;
+
   private Order(User user, Store store, OrderStatus orderStatus) {
     this.user = user;
     this.store = store;
@@ -41,6 +46,17 @@ public class Order {
 
   public static Order of(User user, Store store, OrderStatus orderStatus) {
     return new Order(user, store, orderStatus);
+  }
+
+  @PrePersist
+  private void prePersist() {
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  private void preUpdate() {
+    this.updatedAt = LocalDateTime.now();
   }
 
   @Override

--- a/src/main/java/io/jeidiiy/sirenordersystem/user/domain/User.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/user/domain/User.java
@@ -41,6 +41,10 @@ public class User {
   @Column
   private Role role;
 
+  @Column private LocalDateTime createdAt;
+  
+  @Column private LocalDateTime updatedAt;
+
   @Column private LocalDateTime deletedAt;
 
   @Builder
@@ -50,6 +54,17 @@ public class User {
     this.password = password;
     this.nickname = nickname;
     this.role = Role.CUSTOMER; // 기본값으로 고객으로 저장. 관리자는 별도로 관리
+  }
+
+  @PrePersist
+  private void prePersist() {
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  private void preUpdate() {
+    this.updatedAt = LocalDateTime.now();
   }
 
   @Override


### PR DESCRIPTION
#69 에 따라 사용자 및 주문 엔티티에 메타데이터 기능을 추가했다.

This closes #69 